### PR TITLE
Fix mysql driver issues in project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,13 @@
             <artifactId>jaxb-api</artifactId>
             <version>2.3.0</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.datasource.url = jdbc:mysql://localhost:3306/car
 spring.datasource.username = root
 spring.datasource.password = Victor1303002000
-spring.datasource.driverClassName = com.mysql.jdbc.Driver
+spring.datasource.driverClassName = com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto = create-drop


### PR DESCRIPTION
Noticed an error when running the project:

`2022-12-14T00:54:02.073Z  WARN 6695 --- [           main] c.zaxxer.hikari.util.DriverDataSource    : Registered driver with driverClassName=com.mysql.jdbc.Driver was not found, trying direct instantiation.`

Found this site giving a fix: https://www.traccar.org/forums/topic/why-this-suddenly-registered-driver-with-driverclassnamecommysqljdbcdriver-was-not-found-trying-direct-instantiation/

Doing that and including a mysql driver in the pom.xml seems to have fixed the driver issues.

Hope this helps :)

